### PR TITLE
Change how rspec DSL methods are called on controllers testing

### DIFF
--- a/controllers/restaurants_controller_spec.rb
+++ b/controllers/restaurants_controller_spec.rb
@@ -25,7 +25,7 @@ if defined?(RestaurantsController)
     describe "GET index" do
       it "assigns all restaurants as @restaurants" do
         restaurant = Restaurant.create! valid_attributes
-        get :index, {}, valid_session
+        get :index, params: {}, session: valid_session
         expect(assigns(:restaurants)).to eq([restaurant])
       end
     end
@@ -33,14 +33,14 @@ if defined?(RestaurantsController)
     describe "GET show" do
       it "assigns the requested restaurant as @restaurant" do
         restaurant = Restaurant.create! valid_attributes
-        get :show, {:id => restaurant.to_param}, valid_session
+        get :show, params: {:id => restaurant.to_param}, session: valid_session
         expect(assigns(:restaurant)).to eq(restaurant)
       end
     end
 
     describe "GET new" do
       it "assigns a new restaurant as @restaurant" do
-        get :new, {}, valid_session
+        get :new, params: {}, session: valid_session
         expect(assigns(:restaurant)).to be_a_new(Restaurant)
       end
     end
@@ -49,30 +49,30 @@ if defined?(RestaurantsController)
       describe "with valid params" do
         it "creates a new Restaurant" do
           expect {
-            post :create, {:restaurant => valid_attributes}, valid_session
+            post :create, {:restaurant => valid_attributes}, session: valid_session
           }.to change(Restaurant, :count).by(1)
         end
 
         it "assigns a newly created restaurant as @restaurant" do
-          post :create, {:restaurant => valid_attributes}, valid_session
+          post :create, params: {:restaurant => valid_attributes}, session: valid_session
           expect(assigns(:restaurant)).to be_a(Restaurant)
           expect(assigns(:restaurant)).to be_persisted
         end
 
         it "redirects to the created restaurant" do
-          post :create, {:restaurant => valid_attributes}, valid_session
+          post :create, params: {:restaurant => valid_attributes}, session: valid_session
           expect(response).to redirect_to(Restaurant.last)
         end
       end
 
       describe "with invalid params" do
         it "assigns a newly created but unsaved restaurant as @restaurant" do
-          post :create, {:restaurant => invalid_attributes}, valid_session
+          post :create, params: {:restaurant => invalid_attributes}, session: valid_session
           expect(assigns(:restaurant)).to be_a_new(Restaurant)
         end
 
         it "re-renders the 'new' template" do
-          post :create, {:restaurant => invalid_attributes}, valid_session
+          post :create, params: {:restaurant => invalid_attributes}, session: valid_session
           expect(response).to render_template("new")
         end
       end

--- a/controllers/reviews_controller_spec.rb
+++ b/controllers/reviews_controller_spec.rb
@@ -32,7 +32,7 @@ if defined?(ReviewsController)
 
     describe "GET new" do
       it "assigns a new review as @review" do
-        get :new, { restaurant_id: @restaurant.id }, valid_session
+        get :new, params: { restaurant_id: @restaurant.id }, session: valid_session
         expect(assigns(:restaurant)).to eq(@restaurant)
         expect(assigns(:review)).to be_a_new(Review)
       end
@@ -42,30 +42,30 @@ if defined?(ReviewsController)
       describe "with valid params" do
         it "creates a new Review" do
           expect {
-            post :create, { restaurant_id: @restaurant.id, :review => valid_attributes}, valid_session
+            post :create, params: { restaurant_id: @restaurant.id, :review => valid_attributes}, session: valid_session
           }.to change(Review, :count).by(1)
         end
 
         it "assigns a newly created review as @review" do
-          post :create, { restaurant_id: @restaurant.id, :review => valid_attributes}, valid_session
+          post :create, params: { restaurant_id: @restaurant.id, :review => valid_attributes}, session: valid_session
           expect(assigns(:review)).to be_a(Review)
           expect(assigns(:review)).to be_persisted
         end
 
         it "redirects to the parent restaurant" do
-          post :create, { restaurant_id: @restaurant.id, :review => valid_attributes}, valid_session
+          post :create, params: { restaurant_id: @restaurant.id, :review => valid_attributes}, session: valid_session
           expect(response).to redirect_to(@restaurant)
         end
       end
 
       describe "with invalid params" do
         it "assigns a newly created but unsaved review as @review" do
-          post :create, { restaurant_id: @restaurant.id, :review => invalid_attributes}, valid_session
+          post :create, params: { restaurant_id: @restaurant.id, :review => invalid_attributes}, session: valid_session
           expect(assigns(:review)).to be_a_new(Review)
         end
 
         it "re-renders the 'new' template" do
-          post :create, { restaurant_id: @restaurant.id, :review => invalid_attributes}, valid_session
+          post :create, params: { restaurant_id: @restaurant.id, :review => invalid_attributes}, session: valid_session
           expect(response).to render_template("new")
         end
       end


### PR DESCRIPTION
To get rid of annoying deprecation warnings for students.

<img width="638" alt="screen shot 2017-04-05 at 15 12 46" src="https://cloud.githubusercontent.com/assets/7533706/24692149/7f8aaa36-1a12-11e7-876d-ed4948116dbf.png">
